### PR TITLE
Adds optional maximum length rule for passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Or download `password-rules.js` for a browser.
 Options:
 
 * `minimumLength`: default 8
-* `maximumLength`: default not configured
+* `maximumLength`: default Infinity
 * `requireCapital`: default true
 * `requireLower`: default true
 * `requireNumber`: default true

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Or download `password-rules.js` for a browser.
 Options:
 
 * `minimumLength`: default 8
+* `maximumLength`: default not configured
 * `requireCapital`: default true
 * `requireLower`: default true
 * `requireNumber`: default true

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = function(pw, rules) {
     var issues = [];
     rules = rules || {};
     def(rules, 'minimumLength', 8);
+    def(rules, 'maximumLength', null);
     def(rules, 'requireCapital', true);
     def(rules, 'requireLower', true);
     def(rules, 'requireNumber', true);
@@ -12,6 +13,13 @@ module.exports = function(pw, rules) {
             reason: 'minimumLength',
             message: 'Password must be at least ' + rules.minimumLength + ' letters long',
             part: 'be at least ' + rules.minimumLength + ' letters long'
+        });
+    }
+    if (rules.maximumLength && pw.length > rules.maximumLength) {
+        issues.push({
+            reason: 'maximumLength',
+            message: 'Password must be less than ' + rules.maximumLength + ' letters long',
+            part: 'be less than ' + rules.maximumLength + ' letters long'
         });
     }
     if (rules.requireCapital && !pw.match(/[A-Z]/g)) {

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = function(pw, rules) {
     var issues = [];
     rules = rules || {};
     def(rules, 'minimumLength', 8);
-    def(rules, 'maximumLength', null);
+    def(rules, 'maximumLength', Infinity);
     def(rules, 'requireCapital', true);
     def(rules, 'requireLower', true);
     def(rules, 'requireNumber', true);
@@ -15,7 +15,7 @@ module.exports = function(pw, rules) {
             part: 'be at least ' + rules.minimumLength + ' letters long'
         });
     }
-    if (rules.maximumLength && pw.length > rules.maximumLength) {
+    if (pw.length > rules.maximumLength) {
         issues.push({
             reason: 'maximumLength',
             message: 'Password must be less than ' + rules.maximumLength + ' letters long',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "password-rules",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "enforce rules for reasonable passwords",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/mapbox/password-rules",
   "devDependencies": {
-    "tap": "~1.3.2",
-    "browserify": "~3.18.0"
+    "browserify": "^13.0.1",
+    "tap": "^5.7.1"
   }
 }

--- a/password-rules.js
+++ b/password-rules.js
@@ -1,18 +1,26 @@
-!function(e){if("object"==typeof exports)module.exports=e();else if("function"==typeof define&&define.amd)define(e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.passwordRules=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.passwordRules = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 module.exports = function(pw, rules) {
     var issues = [];
     rules = rules || {};
     def(rules, 'minimumLength', 8);
+    def(rules, 'maximumLength', null);
     def(rules, 'requireCapital', true);
     def(rules, 'requireLower', true);
     def(rules, 'requireNumber', true);
-    def(rules, 'requireSpecial', true);
+    def(rules, 'requireSpecial', false);
 
     if (pw.length < rules.minimumLength) {
         issues.push({
             reason: 'minimumLength',
             message: 'Password must be at least ' + rules.minimumLength + ' letters long',
             part: 'be at least ' + rules.minimumLength + ' letters long'
+        });
+    }
+    if (rules.maximumLength && pw.length > rules.maximumLength) {
+        issues.push({
+            reason: 'maximumLength',
+            message: 'Password must be less than ' + rules.maximumLength + ' letters long',
+            part: 'be less than ' + rules.maximumLength + ' letters long'
         });
     }
     if (rules.requireCapital && !pw.match(/[A-Z]/g)) {
@@ -70,6 +78,5 @@ function def(o, option, val) {
     if (o[option] === undefined) o[option] = val;
 }
 
-},{}]},{},[1])
-(1)
+},{}]},{},[1])(1)
 });

--- a/password-rules.js
+++ b/password-rules.js
@@ -3,7 +3,7 @@ module.exports = function(pw, rules) {
     var issues = [];
     rules = rules || {};
     def(rules, 'minimumLength', 8);
-    def(rules, 'maximumLength', null);
+    def(rules, 'maximumLength', Infinity);
     def(rules, 'requireCapital', true);
     def(rules, 'requireLower', true);
     def(rules, 'requireNumber', true);
@@ -16,7 +16,7 @@ module.exports = function(pw, rules) {
             part: 'be at least ' + rules.minimumLength + ' letters long'
         });
     }
-    if (rules.maximumLength && pw.length > rules.maximumLength) {
+    if (pw.length > rules.maximumLength) {
         issues.push({
             reason: 'maximumLength',
             message: 'Password must be less than ' + rules.maximumLength + ' letters long',

--- a/test/rules.js
+++ b/test/rules.js
@@ -8,6 +8,13 @@ test('issues', function(t) {
         requireNumber: false
     }).issues[0].reason, 'minimumLength', 'requires a minimum length');
 
+    t.equal(rules('4CqKsBN7zcTzCixx59xyXlKE5VmfNW9MxcrQgGkWUEfhgfSULUjsrhD0ZEHAaagUBR8LtgeuZ', {
+        requireCapital: false,
+        maximumLength: 72,
+        requireLower: false,
+        requireNumber: false
+    }).issues[0].reason, 'maximumLength', 'requires a maximum length');
+
     t.equal(rules('foo', {
         requireCapital: true,
         requireLower: false,
@@ -37,6 +44,14 @@ test('sentences', function(t) {
         requireNumber: false,
         requireSpecial: false
     }).sentence, 'Password must be at least 8 letters long.', 'number');
+
+    t.equal(rules('4CqKsBN7zcTzCixx59xyXlKE5VmfNW9MxcrQgGkWUEfhgfSULUjsrhD0ZEHAaagUBR8LtgeuZ', {
+        requireCapital: false,
+        maximumLength: 72,
+        requireLower: false,
+        requireNumber: false,
+        requireSpecial: false
+    }).sentence, 'Password must be less than 72 letters long.', 'number');
 
     t.equal(rules('foo', {
         requireCapital: true,


### PR DESCRIPTION
Adds optional maximum length rule for passwords. Useful to prevent [DoS attacks](https://www.djangoproject.com/weblog/2013/sep/15/security/) on systems where web or middleware servers hash very large passwords. In practice, this should be set to a number large enough for users to create a strong complex password, but short enough to minimize DoS such as 512, 1024, or 2048 characters.

At the moment I wrote this as an optional rule, but I'm open to it being configured by default with a large number such as 4096.

Other changes:
* Updates `password-rules.js` to latest version of `password-rules`
* Updates documentation with new setting
* Bumps browserify and tap deps to latest version
* Bumps version number of `password-rules`

/cc @mapbox/security @tmcw @scothis 